### PR TITLE
Call registered-method after registration

### DIFF
--- a/src/Traits/RegistersUsers.php
+++ b/src/Traits/RegistersUsers.php
@@ -30,7 +30,8 @@ trait RegistersUsers
 
         $this->notifyUser($user);
 
-        return back()->with('confirmation-success', trans('confirmation::confirmation.message'));
+        return $this->registered($request, $user)
+            ?: back()->with('confirmation-success', trans('confirmation::confirmation.message'));
     }
 
     /**


### PR DESCRIPTION
In laravel-source, implemented with v5.3, there's called the method registered after a successful registration. It should be available here, too.
https://github.com/laravel/framework/blob/5.3/src/Illuminate/Foundation/Auth/RegistersUsers.php